### PR TITLE
Run tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install the latest version of rye
       uses: eifinger/setup-rye@v3
+      with:
+        enable-cache: true
     - name: Install dependencies
       run: rye sync
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       run: rye sync
     - name: Run tests
       run: rye test
+    - name: Run invariant.examples
+      run: rye run python -m unittest discover -s invariant/examples -p "*_example.py"
   test-no-extras:
     runs-on: ubuntu-latest
     steps:
@@ -27,4 +29,5 @@ jobs:
     - name: Install dependencies
       run: rye sync --no-dev
     - name: Run tests
-      run: rye test
+      # use 'unittest' explicitly, to prevent rye from install dev dependencies (no extras run)
+      run: rye run python -m unittest discover tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests (all extras)
+name: Run Tests
 
 on:
   push:
@@ -8,17 +8,23 @@ permissions:
   contents: read
 
 jobs:
-  build:
-
+  test-all-extras:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Install the latest version of rye
       uses: eifinger/setup-rye@v3
-      with:
-        enable-cache: true
     - name: Install dependencies
       run: rye sync
+    - name: Run tests
+      run: rye test
+  test-no-extras:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install the latest version of rye
+      uses: eifinger/setup-rye@v3
+    - name: Install dependencies
+      run: rye sync --no-dev
     - name: Run tests
       run: rye test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Run Tests (all extras)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "ci-testing" ]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install the latest version of rye
       uses: eifinger/setup-rye@v3
+    - name: Install dependencies
+      run: rye sync
+    - name: Run tests
+      run: rye test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Run tests
       run: rye test
     - name: Run invariant.examples
-      with:
-        OPENAI_API_KEY: {{ secrets.CI_OPENAI_API_KEY }}
+      env:
+        OPENAI_API_KEY: ${{ secrets.CI_OPENAI_API_KEY }}
       run: rye run python -m unittest discover -s invariant/examples -p "*_example.py"
   test-no-extras:
     name: Test without extra dependencies (some tests will be skipped, but this is the default setup when users install the package)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       run: rye test
   test-examples:
     name: Test invariant.examples
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install the latest version of rye

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   test-all-extras:
+    name: Test with all extra dependencies (expected to include all tests)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -19,8 +20,11 @@ jobs:
     - name: Run tests
       run: rye test
     - name: Run invariant.examples
+      env:
+        OPENAI_API_KEY: {{ secrets.CI_OPENAI_API_KEY }}
       run: rye run python -m unittest discover -s invariant/examples -p "*_example.py"
   test-no-extras:
+    name: Test without extra dependencies (some tests will be skipped, but this is the default setup when users install the package)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,3 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install the latest version of rye
       uses: eifinger/setup-rye@v3
-      with:
-        enable-cache: true
-        cache-prefix: 'optional-prefix'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ permissions:
 
 jobs:
   test-all-extras:
-    name: Test with all extra dependencies (expected to include all tests)
+    name: Test with all extra dependencies
+    # (expected to include all tests)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -19,12 +20,20 @@ jobs:
       run: rye sync
     - name: Run tests
       run: rye test
+  test-examples:
+    name: Test invariant.examples
+    - uses: actions/checkout@v4
+    - name: Install the latest version of rye
+      uses: eifinger/setup-rye@v3
+    - name: Install dependencies
+      run: rye sync # requires all extras
     - name: Run invariant.examples
       env:
         OPENAI_API_KEY: ${{ secrets.CI_OPENAI_API_KEY }}
       run: rye run python -m unittest discover -s invariant/examples -p "*_example.py"
   test-no-extras:
-    name: Test without extra dependencies (some tests will be skipped, but this is the default setup when users install the package)
+    name: Test without extra dependencies
+    # (some tests will be skipped, but this is the default setup when users install the package)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Run Tests (all extras)
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install the latest version of rye
+      uses: eifinger/setup-rye@v3
+      with:
+        enable-cache: true
+        cache-prefix: 'optional-prefix'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run tests
       run: rye test
     - name: Run invariant.examples
-      env:
+      with:
         OPENAI_API_KEY: {{ secrets.CI_OPENAI_API_KEY }}
       run: rye run python -m unittest discover -s invariant/examples -p "*_example.py"
   test-no-extras:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       run: rye test
   test-examples:
     name: Test invariant.examples
+    steps:
     - uses: actions/checkout@v4
     - name: Install the latest version of rye
       uses: eifinger/setup-rye@v3

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -25,7 +25,7 @@ class TestConstants(unittest.TestCase):
 
         input.append({"role": "assistant", "content": "Hello, Y"})
         analysis_result = monitor.analyze(input)
-        assert len(analysis_result.errors) == 0, "Expected no errors, but got: " + str(analysis_result.errors)
+        assert len(analysis_result.errors) == 1, "Expected no errors, but got: " + str(analysis_result.errors)
 
     def test_ref(self):
         policy = Policy.from_string(

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -25,7 +25,7 @@ class TestConstants(unittest.TestCase):
 
         input.append({"role": "assistant", "content": "Hello, Y"})
         analysis_result = monitor.analyze(input)
-        assert len(analysis_result.errors) == 1, "Expected no errors, but got: " + str(analysis_result.errors)
+        assert len(analysis_result.errors) == 0, "Expected no errors, but got: " + str(analysis_result.errors)
 
     def test_ref(self):
         policy = Policy.from_string(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import json
 from invariant import Policy
 from invariant.policy import analyze_trace
 from tests.utils import *
-from invariant.extras import extras_available, presidio_extra, transformers_extra
+from invariant.extras import extras_available, presidio_extra, transformers_extra, codeshield_extra
 
 class TestPII(unittest.TestCase):
     @unittest.skipUnless(extras_available(presidio_extra), "presidio-analyzer is not installed")
@@ -210,6 +210,7 @@ class TestCodeShieldDetector(unittest.TestCase):
         trace = [user("Hello, world!"), user("I am Bob!")]
         self.assertGreater(len(analyze_trace(policy_str, trace).errors), 0)
         
+    @unittest.skipUnless(extras_available(codeshield_extra), "codeshield is not installed")
     def test_code_shield(self):
         policy_str = """
         from invariant.detectors import code_shield, CodeIssue


### PR DESCRIPTION
We now have CI. We run all `tests/` once with all extras installed and once without any extras installed. For CI to pass, all tests that rely on extras must declare that, so they can be skipped in no-extras runs. We also run everything thats a unit test and is located in `invariant.examples.*_example`, which can be used for end-to-end system tests.