### PR TITLE
Parse user inputs to one of the trace event types supported by Invariant

### DIFF
--- a/invariant/policy.py
+++ b/invariant/policy.py
@@ -78,6 +78,9 @@ class Policy:
 
     Use `analyze` to apply the policy to an application state and to obtain a list of violations.
     """
+    policy_root: PolicyRoot
+    rule_set: RuleSet
+    cached: bool
 
     def __init__(self, policy_root: PolicyRoot, cached=False):
         """Creates a new policy with the given policy source.
@@ -113,10 +116,8 @@ class Policy:
         """Implements how errors are added to an analysis result (e.g. as handled or non-handled errors)."""
         analysis_result.errors.append(error)
 
-    def analyze(self, input: Input | dict, raise_unhandled=False, **policy_parameters):
-        # prepare input
-        if type(input) is dict or type(input) is list:
-            input = Input(input, copy=not self.cached)
+    def analyze(self, input: list[dict], raise_unhandled=False, **policy_parameters):
+        input = Input(input)
         
         # prepare policy parameters
         if "data" in policy_parameters:

--- a/invariant/runtime/evaluation.py
+++ b/invariant/runtime/evaluation.py
@@ -317,13 +317,13 @@ class Interpreter(RaisingTransformation):
 
         if hasattr(obj, node.member):
             return getattr(obj, node.member)
-        elif type(obj) is dict:
-            try:
-                return obj[node.member]
-            except KeyError:
-                raise KeyError(f"Object {obj} has no key {node.member}")
-        else:
-            raise KeyError(f"Object {obj} has no member {node.member}")
+
+        try:
+            if type(obj) is str:
+                obj = json.loads(obj)
+            return obj[node.member]
+        except Exception:
+            raise KeyError(f"Object {obj} has no key {node.member}")
 
     def visit_KeyAccess(self, node: KeyAccess):
         obj = self.visit(node.expr)

--- a/invariant/runtime/rule.py
+++ b/invariant/runtime/rule.py
@@ -1,15 +1,13 @@
 import os
 import invariant.language.ast as ast
-from invariant.runtime.evaluation import Interpreter, EvaluationContext, VariableDomain, Unknown
-from invariant.language.linking import link
-import invariant.language.types as types
-from invariant.language.parser import parse_file
-import invariant.language.ast as ast
-from dataclasses import dataclass
-from itertools import product
 import textwrap
 import termcolor
+import invariant.language.ast as ast
+from itertools import product
+from invariant.language.linking import link
 from invariant.runtime.input import Selectable, Input
+from invariant.runtime.evaluation import Interpreter, EvaluationContext, VariableDomain, Unknown
+from inspect import ismethod
 
 class PolicyAction:
     def __call__(self, input_dict):
@@ -198,7 +196,7 @@ class FunctionCache:
     
     def call(self, function, args, **kwargs):
         # check if function is marked as @nocache (see ./functions.py module)
-        if hasattr(function, "__invariant_nocache__"):
+        if True: # hasattr(function, "__invariant_nocache__"):
             return function(*args, **kwargs)
         if not self.contains(function, args, kwargs):
             self.cache[self.call_key(function, args, kwargs)] = function(*args, **kwargs)
@@ -259,7 +257,7 @@ class RuleSet:
         model_str = textwrap.wrap(repr(model), width=120, subsequent_indent="         ")
         print("  Model:", "\n".join(model_str))
 
-    def apply(self, input_data, policy_parameters):
+    def apply(self, input_data: Input, policy_parameters):
         exceptions = []
         
         self.input = input_data

--- a/invariant/runtime/utils/code.py
+++ b/invariant/runtime/utils/code.py
@@ -60,6 +60,9 @@ class PythonDetectorResult:
             raise ValueError("Expected PythonDetectorResult object")
         self.imports.extend(other.imports)
         self.builtins.extend(other.builtins)
+        self.function_calls.update(other.function_calls)
+        if other.syntax_error:
+            self.syntax_error = True
 
 
 class ASTDetectionVisitor(ast.NodeVisitor):

--- a/invariant/stdlib/invariant/detectors/code.py
+++ b/invariant/stdlib/invariant/detectors/code.py
@@ -11,16 +11,16 @@ def python_code(data: str | list | dict, **config: dict) -> PythonDetectorResult
     if PYTHON_ANALYZER is None:
         PYTHON_ANALYZER = PythonCodeDetector()
 
-    chat = data if isinstance(data, list) else ([{"content": data}] if type(data) == str else [data])
-    
-    res = None
-    for message in chat:
-        if message is None:
+    if type(data) is str:
+        return PYTHON_ANALYZER.detect(data, **config)
+    if type(data) is not list:
+        data = [data]
+
+    res = PythonDetectorResult()
+    for message in data:
+        if message.content is None:
             continue
-        if message["content"] is None:
-            continue
-        new_res = PYTHON_ANALYZER.detect(message["content"], **config)
-        res = new_res if res is None else res.extend(new_res)
+        res.extend(PYTHON_ANALYZER.detect(message.content, **config))
     return res
 
 
@@ -31,16 +31,16 @@ def code_shield(data: str | list | dict, **config: dict) -> list[CodeIssue]:
     if CODE_SHIELD_DETECTOR is None:
         CODE_SHIELD_DETECTOR = CodeShieldDetector()
 
-    chat = data if isinstance(data, list) else ([{"content": data}] if type(data) == str else [data])
-    
-    res = None
-    for message in chat:
-        if message is None:
+    if type(data) is str:
+        return CODE_SHIELD_DETECTOR.detect_all(data, **config)
+    if type(data) is not list:
+        data = [data]
+
+    res = []
+    for message in data:
+        if message.content is None:
             continue
-        if message["content"] is None:
-            continue
-        new_res = CODE_SHIELD_DETECTOR.detect_all(message["content"], **config)
-        res = new_res if res is None else res.extend(new_res)
+        res.extend(CODE_SHIELD_DETECTOR.detect_all(message.content, **config))
     return res
 
 
@@ -51,14 +51,14 @@ def semgrep(data: str | list | dict, **config: dict) -> list[CodeIssue]:
     if SEMGREP_DETECTOR is None:
         SEMGREP_DETECTOR = SemgrepDetector()
 
+    if type(data) is str:
+        return SEMGREP_DETECTOR.detect_all(data, **config)
+
     chat = data if isinstance(data, list) else ([{"content": data}] if type(data) == str else [data])
 
-    res = None
+    res = []
     for message in chat:
-        if message is None:
+        if message.content is None:
             continue
-        if message["content"] is None:
-            continue
-        new_res = SEMGREP_DETECTOR.detect_all(message["content"], **config)
-        res = new_res if res is None else res.extend(new_res)
+        res.extend(SEMGREP_DETECTOR.detect_all(message.content, **config))
     return res

--- a/invariant/stdlib/invariant/detectors/moderation.py
+++ b/invariant/stdlib/invariant/detectors/moderation.py
@@ -15,16 +15,16 @@ def moderated(data: str | list | dict, **config: dict) -> bool:
     if MODERATION_ANALYZER is None:
         MODERATION_ANALYZER = ModerationAnalyzer()
 
-    chat = data if isinstance(data, list) else ([{"content": data}] if type(data) == str else [data])
-    
-    for message in chat:
-        if message is None:
-            continue
-        if message["content"] is None:
-            continue
-        if MODERATION_ANALYZER.detect(message["content"], **config):
-            return True
+    if type(data) is str:
+        return MODERATION_ANALYZER.detect(data, **config)
+    if type(data) is not list:
+        data = [data]
 
+    for message in data:
+        if message is None or message.content is None:
+            continue
+        if MODERATION_ANALYZER.detect(message.content, **config):
+            return True
     return False
 
 

--- a/invariant/stdlib/invariant/detectors/pii.py
+++ b/invariant/stdlib/invariant/detectors/pii.py
@@ -20,13 +20,14 @@ def pii(data: str | list, **config):
         from invariant.runtime.utils.pii import PII_Analyzer
         PII_ANALYZER = PII_Analyzer()
 
-    chat = data if isinstance(data, list) else ([{"content": data}] if type(data) == str else [data])
+    if type(data) is str:
+        return PII_ANALYZER.detect_all(data)
+    if type(data) is not list:
+        data = [data]
     
     all_pii = []
-    for message in chat:
-        if message is None:
+    for message in data:
+        if message.content is None:
             continue
-        if message["content"] is None:
-            continue
-        all_pii.extend(PII_ANALYZER.detect_all(message["content"]))
+        all_pii.extend(PII_ANALYZER.detect_all(message.content))
     return all_pii

--- a/invariant/stdlib/invariant/detectors/prompt_injection.py
+++ b/invariant/stdlib/invariant/detectors/prompt_injection.py
@@ -15,16 +15,16 @@ def prompt_injection(data: str | list | dict, **config: dict) -> bool:
     if PROMPT_INJECTION_ANALYZER is None:
         PROMPT_INJECTION_ANALYZER = PromptInjectionAnalyzer()
 
-    chat = data if isinstance(data, list) else ([{"content": data}] if type(data) == str else [data])
+    if type(data) is str:
+        return PROMPT_INJECTION_ANALYZER.detect_all(data, **config)
+    if type(data) is not list:
+        data = [data]
 
-    for message in chat:
-        if message is None:
+    for message in data:
+        if message.content is None:
             continue
-        if message["content"] is None:
-            continue
-        if PROMPT_INJECTION_ANALYZER.detect(message["content"], **config):
+        if PROMPT_INJECTION_ANALYZER.detect(message.content, **config):
             return True
-
     return False
 
 
@@ -35,16 +35,15 @@ def unicode(data: str | list | dict, **config: dict) -> bool:
     if UNICODE_ANALYZER is None:
         UNICODE_ANALYZER = UnicodeDetector()
 
-    chat = data if isinstance(data, list) else ([{"content": data}] if type(data) == str else [data])
+    if type(data) is str:
+        return UNICODE_ANALYZER.detect_all(data, **config)
+    if type(data) is not list:
+        data = [data]
 
     all_unicode = []
-    for message in chat:
-        if message is None:
+    for message in data:
+        if message.content is None:
             continue
-        if message["content"] is None:
-            continue
-        
-        res = UNICODE_ANALYZER.detect_all(message["content"], **config)
+        res = UNICODE_ANALYZER.detect_all(message.content, **config)
         all_unicode.extend(UNICODE_ANALYZER.get_entities(res))
-    
     return all_unicode

--- a/invariant/stdlib/invariant/detectors/secrets.py
+++ b/invariant/stdlib/invariant/detectors/secrets.py
@@ -22,10 +22,10 @@ def secrets(data: str | list | dict, **config: dict) -> list[str]:
     for message in chat:
         if message is None:
             continue
-        if message["content"] is None:
+        if message.content is None:
             continue
         
-        res = SECRETS_ANALYZER.detect_all(message["content"], **config)
+        res = SECRETS_ANALYZER.detect_all(message.content, **config)
         all_secrets.extend(SECRETS_ANALYZER.get_entities(res))
     return all_secrets
 

--- a/invariant/stdlib/invariant/nodes.py
+++ b/invariant/stdlib/invariant/nodes.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Union
+from pydantic.dataclasses import dataclass
+from typing import Optional
 
 @dataclass
 class LLM:
@@ -7,15 +7,16 @@ class LLM:
     model: str
 
 @dataclass
-class Message:
-    content: str
-    role: str
-
-@dataclass
 class ToolCall:
     id: str
     type: str
     function: list
+
+@dataclass
+class Message:
+    content: str
+    role: str
+    tool_calls: Optional[list[ToolCall]] = None
 
 @dataclass
 class Function:
@@ -28,6 +29,8 @@ class ToolOutput:
     content: str
     tool_call_id: str
 
+TraceEvent = Message | ToolCall | ToolOutput
+
 @dataclass
 class Trace:
-    elements: Message | ToolCall | ToolOutput
+    elements: list[TraceEvent]

--- a/invariant/stdlib/invariant/nodes.py
+++ b/invariant/stdlib/invariant/nodes.py
@@ -1,4 +1,5 @@
 from pydantic.dataclasses import dataclass
+from pydantic import BaseModel
 from typing import Optional
 
 @dataclass
@@ -6,31 +7,30 @@ class LLM:
     vendor: str
     model: str
 
-@dataclass
-class ToolCall:
-    id: str
-    type: str
-    function: list
-
-@dataclass
-class Message:
-    content: str
-    role: str
-    tool_calls: Optional[list[ToolCall]] = None
-
-@dataclass
-class Function:
+class Function(BaseModel):
     name: str
     arguments: dict
 
-@dataclass
-class ToolOutput:
+class ToolCall(BaseModel):
+    id: str
+    type: str
+    function: Function
+    data: Optional[dict] = None
+
+class Message(BaseModel):
+    content: Optional[str]
+    role: str
+    tool_calls: Optional[list[ToolCall]] = None
+    data: Optional[dict] = None
+
+class ToolOutput(BaseModel):
     role: str
     content: str
-    tool_call_id: str
+    tool_call_id: Optional[str]
+    data: Optional[dict] = None
 
-TraceEvent = Message | ToolCall | ToolOutput
+    _tool_call: Optional[ToolCall]
 
-@dataclass
-class Trace:
-    elements: list[TraceEvent]
+Event = Message | ToolCall | ToolOutput
+
+

--- a/invariant/stdlib/invariant/parsers/html.py
+++ b/invariant/stdlib/invariant/parsers/html.py
@@ -1,10 +1,11 @@
 from html.parser import HTMLParser
 from dataclasses import dataclass
 import re
+from invariant.stdlib.invariant.nodes import Message, ToolCall, ToolOutput
 
 @dataclass
 class HiddenHTMLData:
-    alt_texts: str
+    alt_texts: list[str]
     links: list[str]
 
 class HiddenDataParser(HTMLParser):
@@ -58,9 +59,12 @@ def html_code(data: str | list | dict, **config: dict) -> HiddenHTMLData:
     for message in chat:
         if message is None:
             continue
-        if "content" in message and message["content"] is None:
-            continue
-        content = message.get("content", str(message))
+        if type(message) is ToolCall:
+            content = str(message)
+        else:
+            if message.content is None:
+                continue
+            content = message.content
         parser = HiddenDataParser()
         parser.parse(content)
         
@@ -83,8 +87,8 @@ def links(data: str | list | dict, **config: dict) -> list[str]:
     for message in chat:
         if message is None:
             continue
-        if message["content"] is None:
+        if message.content is None:
             continue
-        res.extend(HiddenDataParser.get_links_regex(message["content"]))
+        res.extend(HiddenDataParser.get_links_regex(message.content))
 
     return res

--- a/invariant/traces.py
+++ b/invariant/traces.py
@@ -22,4 +22,4 @@ def tool_call(tool_call_id, function_name, arguments):
     }
 
 def tool(tool_call_id, content):
-    return {"role": "tool", "tool_call_id": tool_call_id, "content": content}
+    return {"role": "tool", "tool_call_id": tool_call_id, "content": str(content)}

--- a/tests/custom_checker_project/checker.py
+++ b/tests/custom_checker_project/checker.py
@@ -1,2 +1,4 @@
-def contains_hello(msg: dict) -> bool:
-    return "hello" in msg["content"]
+from invariant.stdlib.invariant.nodes import Message
+
+def contains_hello(msg: Message) -> bool:
+    return "hello" in msg.content

--- a/tests/test_derived_variables.py
+++ b/tests/test_derived_variables.py
@@ -33,7 +33,7 @@ class TestDerivedVariables(unittest.TestCase):
     def test_twolevel_subselect(self):
         policy = Policy.from_string(
         """
-        raise "error" if:
+        raise PolicyViolation(line=line, word=word) if:
             (msg: Message)
             (line: str) in msg.content.splitlines()
             (word: str) in line.split(" ")
@@ -58,7 +58,7 @@ class TestDerivedVariables(unittest.TestCase):
     def test_exclude_submodels(self):
         policy = Policy.from_string(
         """
-        raise "error" if:
+        raise PolicyViolation(line=line, word=word) if:
             (msg: Message)
             msg.data["a"] > 2 # cond 1
             lines := msg.content.splitlines()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4,14 +4,14 @@ from invariant import Policy, RuleSet, Monitor
 from invariant.runtime.input import Dataflow
 from invariant.extras import extras_available, presidio_extra, transformers_extra
 from invariant.traces import *
+
 class TestFlow(unittest.TestCase):
     def test_simple(self):
         policy = Policy.from_string(
         """
-        raise PolicyViolation("you must not call something_else after something", call=call, call2=call2) if:
-            (call: ToolCall) -> (call2: ToolCall)
-            call is tool:something({x: 2})
-            call2 is tool:something_else({x: 10})
+        raise PolicyViolation("you must not call something_else after something") if:
+            (call: ToolCall)
+            call is tool:something
         """
         )
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -9,9 +9,10 @@ class TestFlow(unittest.TestCase):
     def test_simple(self):
         policy = Policy.from_string(
         """
-        raise PolicyViolation("you must not call something_else after something") if:
-            (call: ToolCall)
-            call is tool:something
+        raise PolicyViolation("you must not call something_else after something", call=call, call2=call2) if:
+            (call: ToolCall) -> (call2: ToolCall)
+            call is tool:something({x: 2})
+            call2 is tool:something_else({x: 10})
         """
         )
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,6 +1,8 @@
+import copy
 import unittest
 import json
 from invariant import Policy, Monitor
+from invariant.stdlib.invariant import *
 
 class TestMonitor(unittest.TestCase):
     def test_simple(self):
@@ -62,6 +64,34 @@ class TestMonitor(unittest.TestCase):
         assert input[0]["content"] == "Hello, world!", "Expected 'Hello, world!' after append, but got: " + input[0]["content"]
         assert input[1]["content"] == "Hello, world!", "Expected 'Hello, world!' after append, but got: " + input[1]["content"]
         assert input[2]["content"] == "Hello, world", "Expected 'Hello, world' after append, but got: " + input[2]["content"]
+
+    def test_objects(self):
+        policy = Monitor.from_string(
+        """
+        from invariant import Message, PolicyViolation
+
+        raise PolicyViolation("Cannot send user message:", msg) if:
+            (msg: Message)
+            msg.role == "user"
+        """)
+
+        events = [
+            {"role": "user", "content": "Hello, world!"},
+            {"role": "assistant", "content": "Hello, world!"}
+        ]
+        input = []
+        input += [events[0]]
+        res = policy.analyze(input)
+        self.assertTrue(len(res.errors) == 1)
+
+        input += [events[1]]
+        res = policy.analyze(input)
+        self.assertTrue(len(res.errors) == 0)
+
+        import copy
+        res = policy.analyze(copy.deepcopy(input))
+        self.assertTrue(len(res.errors) == 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -76,8 +76,8 @@ class TestMonitor(unittest.TestCase):
         """)
 
         events = [
-            {"role": "user", "content": "Hello, world!"},
-            {"role": "assistant", "content": "Hello, world!"}
+            Message(role="user", content="Hello, world!"),
+            Message(role="assistant", content="Hello, world!")
         ]
         input = []
         input += [events[0]]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,7 +137,6 @@ class TestSecrets(unittest.TestCase):
             'SLACK_TOKEN': ['abde-123456789012-1234567890123-1234567890123-1234567890123'],
         }
 
-    @unittest.skipUnless(extras_available(presidio_extra), "presidio-analyzer is not installed")
     def test_detect_valid_secrets(self):
         policy_str_template = """
         from invariant.detectors import secrets


### PR DESCRIPTION
The main goal of this PR is to change input given to the analyzer to be list of known trace events (Message, ToolCall and ToolOutput). This simplifies the analyzer code as now we know ahead of time what types can be expected (e.g. in selector), and if user input does not conform to the format it should not be parsed.

This PR still does not include two orthogonal changes that will be addressed separately:
- Here we switch off function caching as it has problems with object methods like `line.split(...)` where caching would need to be aware of the current object value.
- Monitor should expose function `analyze(trace, new_actions)` allowing it to become stateless and only raise errors that relate to new actions that have not yet been executed. This will remove the need for storing previous errors.

