### PR TITLE
Update InvariantValue type so that the value field cannot be reassigned once set.

### DIFF
--- a/testing/invariant/custom_types/invariant_value.py
+++ b/testing/invariant/custom_types/invariant_value.py
@@ -22,13 +22,24 @@ class InvariantValue:
         ):
             raise TypeError("addresses must be a list of strings")
 
-        self.value = value
+        self._value = value
         self.addresses = addresses if addresses is not None else []
 
-        if isinstance(self.value, str):
+        if isinstance(self._value, str):
             for i, a in enumerate(self.addresses):
                 if ":" not in a:
-                    self.addresses[i] = a + ":0-" + str(len(self.value))
+                    self.addresses[i] = a + ":0-" + str(len(self._value))
+
+    @property
+    def value(self):
+        """Read-only property for the value field."""
+        return self._value
+
+    def __setattr__(self, name, new_value):
+        """Customize attribute setting to prevent `value` from being reassigned."""
+        if name == "value":
+            raise AttributeError("The 'value' attribute cannot be reassigned.")
+        super().__setattr__(name, new_value)
 
     @staticmethod
     def of(value: Any, address: list[str]) -> InvariantValue | "InvariantDict" | None:

--- a/testing/tests/custom_types/test_invariant_bool.py
+++ b/testing/tests/custom_types/test_invariant_bool.py
@@ -1,6 +1,7 @@
 """Tests for the InvariantBool class."""
 
 import pytest
+
 from invariant.custom_types.invariant_bool import InvariantBool
 
 
@@ -177,6 +178,10 @@ def test_invariant_bool_with_addresses():
     assert bool1 != False  # noqa: E712 pylint: disable=singleton-comparison
     assert bool1.addresses == ["address1"]
     assert bool3.addresses == ["address2"]
+
+    # The value field is read-only.
+    with pytest.raises(AttributeError, match="'value' attribute cannot be reassigned"):
+        bool1.value = False
 
 
 @pytest.mark.parametrize(

--- a/testing/tests/custom_types/test_invariant_image.py
+++ b/testing/tests/custom_types/test_invariant_image.py
@@ -64,3 +64,16 @@ def test_ocr_detector():
     assert not inv_img.ocr_contains_all(["agents", "making", "LLM"])
     assert inv_img.ocr_contains_any(["something", "agents", "abc"])
     assert not inv_img.ocr_contains_any(["something", "def", "abc"])
+
+
+def test_invariant_image_value_no_reassignment():
+    """Test that the value of an InvariantImage cannot be reassigned."""
+    with (
+        open("sample_tests/assets/inv_labs.png", "rb") as image_file_1,
+        open("sample_tests/assets/Group_of_cats_resized.jpg", "rb") as image_file_2,
+    ):
+        base64_image_1 = base64.b64encode(image_file_1.read()).decode("utf-8")
+        base64_image_2 = base64.b64encode(image_file_2.read()).decode("utf-8")
+        inv_img = InvariantImage(base64_image_1)
+        with pytest.raises(AttributeError, match="'value' attribute cannot be reassigned"):
+            inv_img.value = base64_image_2

--- a/testing/tests/custom_types/test_invariant_number.py
+++ b/testing/tests/custom_types/test_invariant_number.py
@@ -1,6 +1,7 @@
 """Tests for the InvariantNumber class."""
 
 import pytest
+
 from invariant.custom_types.invariant_bool import InvariantBool
 from invariant.custom_types.invariant_number import InvariantNumber
 
@@ -14,6 +15,10 @@ def test_invariant_number_initialization():
     num = InvariantNumber(3.14)
     assert num.value == 3.14
     assert num.addresses == []
+
+    # The value field is read-only.
+    with pytest.raises(AttributeError, match="'value' attribute cannot be reassigned"):
+        num.value = 5
 
     with pytest.raises(TypeError, match="value must be an int or float"):
         InvariantNumber("not_a_number")

--- a/testing/tests/custom_types/test_invariant_string.py
+++ b/testing/tests/custom_types/test_invariant_string.py
@@ -26,6 +26,10 @@ def test_invariant_string_initialization():
     assert string.upper() == "WORLD"
     assert string.lower() == "world"
 
+    # The value field is read-only.
+    with pytest.raises(AttributeError, match="'value' attribute cannot be reassigned"):
+        string.value = "new value"
+
     # Test invalid value type
     with pytest.raises(TypeError, match="value must be a str"):
         InvariantString(123)

--- a/testing/tests/custom_types/test_invariant_value.py
+++ b/testing/tests/custom_types/test_invariant_value.py
@@ -1,6 +1,7 @@
 """Tests for the InvariantValue class."""
 
 import pytest
+
 from invariant.custom_types.invariant_bool import InvariantBool
 from invariant.custom_types.invariant_dict import InvariantDict
 from invariant.custom_types.invariant_number import InvariantNumber
@@ -11,13 +12,17 @@ from invariant.custom_types.matchers import LambdaMatcher
 
 def test_invariant_value_initialization():
     """Test initialization of InvariantValue."""
-    value = InvariantValue("test", ["address1"])
-    assert value.value == "test"
-    assert value.addresses == ["address1:0-4"]
+    invariant_value = InvariantValue("test", ["address1"])
+    assert invariant_value.value == "test"
+    assert invariant_value.addresses == ["address1:0-4"]
 
-    value = InvariantValue(123)
-    assert value.value == 123
-    assert value.addresses == []
+    invariant_value = InvariantValue(123)
+    assert invariant_value.value == 123
+    assert invariant_value.addresses == []
+
+    # The value field is read-only.
+    with pytest.raises(AttributeError, match="'value' attribute cannot be reassigned"):
+        invariant_value.value = "new value"
 
     with pytest.raises(TypeError, match="addresses must be a list of strings"):
         InvariantValue("test", ["address1", 123])


### PR DESCRIPTION
https://trello.com/c/HED9eq2A/82-consider-immutability-of-the-invariant-types