### PR TITLE
CLI tool for pulling and launching Explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ test.py
 
 # Custom directory
 .invariant/
+data

--- a/testing/invariant/__main__.py
+++ b/testing/invariant/__main__.py
@@ -20,6 +20,7 @@ from invariant.constants import (
     INVARIANT_TEST_RUNNER_CONFIG_ENV_VAR,
     INVARIANT_TEST_RUNNER_TERMINAL_WIDTH_ENV_VAR,
 )
+from invariant.explorer import launch_explorer
 from invariant.utils import utils
 
 # Configure logging
@@ -68,9 +69,11 @@ def create_config(args: argparse.Namespace) -> Config:
     """Create and return a Config instance based on parsed arguments and environment variables.
 
     Args:
+    ----
         args (argparse.Namespace): Parsed command-line arguments.
 
     Returns:
+    -------
         Config: Config instance with dataset name, push status, and API key.
 
     """
@@ -203,7 +206,7 @@ def main():
         "help": "Shows this help message",
     }
 
-    if len(sys.argv) < 2 or sys.argv[1] not in actions or sys.argv[1] == "help":
+    if len(sys.argv) < 2:
         print("Usage: invariant <command> [<args>]")
         print("\nSupported Commands:\n")
         for verb, description in actions.items():
@@ -214,6 +217,8 @@ def main():
     verb = sys.argv[1]
     if verb == "test":
         return test(sys.argv[2:])
+    elif verb == "explorer":
+        return launch_explorer(sys.argv[2:])
     else:
         print(f"Unknown action: {verb}")
         return 1

--- a/testing/invariant/__main__.py
+++ b/testing/invariant/__main__.py
@@ -203,6 +203,7 @@ def main():
     """Entry point for the Invariant Runner."""
     actions = {
         "test": "Runs a specified test (folder) with Invariant test (pytest compatible arguments)",
+        "explorer": "Launch the Invariant Explorer as a local Docker compose application (requires Docker)",
         "help": "Shows this help message",
     }
 

--- a/testing/invariant/explorer.py
+++ b/testing/invariant/explorer.py
@@ -2,11 +2,14 @@
 """CLI to launch the Invariant Explorer as a Docker compose application."""
 
 import argparse
+import io
 import os
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
+import pexpect
 import requests
 
 parser = argparse.ArgumentParser(
@@ -26,55 +29,12 @@ parser.add_argument(
     help="Branch or version of the Invariant Explorer to use.",
 )
 
+# all other non-flag arguments
+parser.add_argument("args", nargs=argparse.REMAINDER)
+# all other flags
+parser.add_argument("flags", nargs=argparse.REMAINDER)
+
 args = None
-
-
-def ensure_has_docker_compose():
-    """Ensure that the user has Docker Compose installed."""
-    try:
-        p = subprocess.Popen(
-            ["docker", "compose", "--version"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        p.communicate()
-
-        if p.returncode != 0:
-            raise Exception(
-                "Docker Compose is not installed. Please go to https://docs.docker.com/compose/install/ to install it and then re-run this command."
-            )
-    except FileNotFoundError:
-        raise Exception(
-            "Docker Compose is not installed. Please go to https://docs.docker.com/compose/install/ to install it and then re-run this command."
-        )
-
-
-def ensure_has_docker_network():
-    """Ensure that the user has the Docker network that the Invariant Explorer uses `invariant-explorer-web`."""
-    p = subprocess.Popen(
-        ["docker", "network", "ls", "--filter", "name=invariant-explorer-web"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    p.communicate()
-
-    if p.returncode != 0:
-        p = subprocess.Popen(
-            ["docker", "network", "create", "invariant-explorer-web"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        p.communicate()
-
-        if p.returncode != 0:
-            raise Exception(
-                "Failed to create the Docker network that the Invariant Explorer uses. Please check the logs for more information."
-            )
-
-
-def ensure_has_db_folder():
-    """Ensure that the user has the database folder that the Invariant Explorer uses."""
-    Path("./data/database").mkdir(parents=True, exist_ok=True)
 
 
 # list active tags of repo
@@ -82,7 +42,12 @@ def released_versions(repository):
     """List the tags of a GitHub repository."""
     try:
         url = f"https://api.github.com/repos/{repository}/tags"
-        r = requests.get(url)
+        r = requests.get(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15"
+            },
+        )
         r.raise_for_status()
 
         releases = []
@@ -96,6 +61,12 @@ def released_versions(repository):
         return releases
 
     # not connected to the internet
+    except requests.exceptions.HTTPError as e:
+        # check for rate limits
+        if e.response.status_code == 403:
+            print("GitHub API rate limit reached, please try again later.")
+            return [{"name": "v0.0.2"}]
+            exit(1)
     except requests.exceptions.ConnectionError:
         print(
             "Failed to connect to the internet. Please check your connection and try again. `invariant explorer` requires an internet connection to download and update the necessary Docker images."
@@ -112,7 +83,12 @@ def github_file(repository, tag, path):
             else f"https://raw.githubusercontent.com/{repository}/refs/tags/{tag}/{path}"
         )
         print("[Updating]", url)
-        r = requests.get(url)
+        r = requests.get(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15"
+            },
+        )
         r.raise_for_status()
         return r.text
     # not connected to the internet
@@ -155,81 +131,177 @@ def config_file(version):
     return tf.name
 
 
-def ensure_dot_env_exists():
-    """Ensure that the user has a `.env` file for the Invariant Explorer."""
-    if not os.path.exists(".env"):
-        with open(".env", "w") as f:
-            f.write("""POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=invariantmonitor
-POSTGRES_HOST=database""")
+class ExplorerLauncher:
+    """Class to launch the Invariant Explorer as a Docker compose application."""
+
+    def __init__(self, args):
+        self.args = args
+
+        # gets the config and docker compose files for the specified version or branch
+        version = args.version
+        if version == "stable":
+            versions = released_versions("invariantlabs-ai/explorer-public")
+            if len(versions) == 0:
+                print(
+                    "No published versions of Explorer found. Please specify a specific version using --version=vX.Y.Z."
+                )
+                exit(1)
+            version = versions[0]["name"]
+
+        self.version = version
+
+        # download the files for the specified version
+        self.compose_file = docker_compose_setup(version)
+        self.config = config_file(version)
+
+    def ensure_has_docker_compose(self):
+        """Ensure that the user has Docker Compose installed."""
+        try:
+            p = subprocess.Popen(
+                ["docker", "compose", "--version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            p.communicate()
+
+            if p.returncode != 0:
+                raise Exception(
+                    "Docker Compose is not installed. Please go to https://docs.docker.com/compose/install/ to install it and then re-run this command."
+                )
+        except FileNotFoundError:
+            raise Exception(
+                "Docker Compose is not installed. Please go to https://docs.docker.com/compose/install/ to install it and then re-run this command."
+            )
+
+    def ensure_has_docker_network(self):
+        """Ensure that the user has the Docker network that the Invariant Explorer uses `invariant-explorer-web`."""
+        p = subprocess.Popen(
+            ["docker", "network", "ls", "--filter", "name=invariant-explorer-web"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        p.communicate()
+
+        if p.returncode != 0:
+            p = subprocess.Popen(
+                ["docker", "network", "create", "invariant-explorer-web"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            p.communicate()
+
+            if p.returncode != 0:
+                raise Exception(
+                    "Failed to create the Docker network that the Invariant Explorer uses. Please check the logs for more information."
+                )
+
+    def ensure_has_db_folder(self):
+        """Ensure that the user has the database folder that the Invariant Explorer uses."""
+        Path("./data/database").mkdir(parents=True, exist_ok=True)
+
+    def ensure_dot_env_exists(self):
+        """Ensure that the user has a `.env` file for the Invariant Explorer."""
+        if not os.path.exists(".env"):
+            with open(".env", "w") as f:
+                f.write("""POSTGRES_USER=postgres
+    POSTGRES_PASSWORD=postgres
+    POSTGRES_DB=invariantmonitor
+    POSTGRES_HOST=database""")
+
+    def env(self):
+        """Get the environment variables for the Invariant Explorer."""
+        return {
+            **dict(os.environ),
+            "APP_NAME": "invariant-explorer",
+            "DEV_MODE": "true",
+            "CONFIG_FILE_NAME": self.config,
+            "PREVIEW": "0",
+            "PORT_HTTP": str(self.args.port),
+            "PORT_API": "8000",
+            "KEYCLOAK_CLIENT_ID_SECRET": "local-does-not-use-keycloak",  # for local development
+            "VERSION": self.version if self.version != "main" else "latest",
+        }
+
+    def ensure_db_ready(self):
+        """Launches and waits for the database to be ready. Then terminates the database container."""
+        # log the output
+        log = io.BytesIO()
+
+        print("[Preparing database]")
+
+        # use pexpect and wait for 'database system is ready to accept connections'
+        p = pexpect.spawn(
+            "docker compose -f "
+            + self.compose_file
+            # disable fancy docker output
+            + " -p invariant-explorer --project-directory . --no-ansi up database",
+            env={**self.env(), "DOCKER_SCAN_SUGGEST": "false"},
+            logfile=log,
+        )
+
+        try:
+            p.expect("database system is ready to accept connections", timeout=5)
+
+            p.sendcontrol("c")
+            p.expect(pexpect.EOF)
+            assert p.exitstatus is None
+            print("[Database ready]")
+        except pexpect.exceptions.ExceptionPexpect:
+            print("Database is not ready. Please check the logs for more information.")
+            print(log.getvalue().decode("utf-8"))
+            exit(1)
+
+    def launch(self, args: list[str]):
+        """Launches the Invariant Explorer."""
+        cmd = [
+            "docker",
+            "compose",
+            "-f",
+            self.compose_file,
+            "-p",
+            "invariant-explorer",
+            "--project-directory",
+            ".",
+            *args,
+        ]
+        print("[Launching]", " ".join(cmd))
+        p = subprocess.Popen(
+            # make sure paths are relative to the current directory
+            cmd,
+            env=self.env(),
+        )
+
+        p.communicate()
+
+        if p.returncode != 0:
+            raise Exception(
+                "Failed to launch the Invariant Explorer. Please check the logs for more information."
+            )
+
+    def ensure_ready(self):
+        self.ensure_has_docker_compose()
+        self.ensure_has_docker_network()
+        self.ensure_has_db_folder()
+        self.ensure_dot_env_exists()
 
 
 def launch_explorer(args=None):
     """Launch the Invariant Explorer as a Docker compose application."""
-    # download l
-
     if args is None:
         args = parser.parse_args()
     else:
         args = parser.parse_args(args)
 
-    # gets the config and docker compose files for the specified version or branch
-    version = args.version
-    if version == "stable":
-        versions = released_versions("invariantlabs-ai/explorer-public")
-        if len(versions) == 0:
-            print(
-                "No published versions of Explorer found. Please specify a specific version using --version=vX.Y.Z."
-            )
-            exit(1)
-        version = versions[0]["name"]
+    launcher = ExplorerLauncher(args)
+    print("[version]", launcher.version)
 
-    # download the files for the specified version
-    compose_file = docker_compose_setup(version)
-    cf = config_file(version)
-
-    # sets up environment
-    ensure_has_docker_compose()
-    ensure_has_docker_network()
-    ensure_has_db_folder()
-    ensure_dot_env_exists()
-
-    env = {
-        **dict(os.environ),
-        "APP_NAME": "explorer-local",
-        "DEV_MODE": "true",
-        "CONFIG_FILE_NAME": cf,
-        "PREVIEW": "0",
-        "PORT_HTTP": str(args.port),
-        "PORT_API": "8000",
-        "KEYCLOAK_CLIENT_ID_SECRET": "local-does-not-use-keycloak",
-        # for 'main' we pull the latest image
-        "VERSION": version if version != "main" else "latest",
-    }
-
-    print("[version]", env["VERSION"])
-
-    p = subprocess.Popen(
-        # make sure paths are relative to the current directory
-        [
-            "docker",
-            "compose",
-            "-f",
-            compose_file,
-            "--project-directory",
-            ".",
-            "up",
-            "--build",
-        ],
-        env=env,
-    )
-    p.communicate()
-
-    if p.returncode != 0:
-        raise Exception(
-            "Failed to launch the Invariant Explorer. Please check the logs for more information."
-        )
+    # sets up environment and checks for dependencies
+    launcher.ensure_ready()
+    # ensures DB is initialized
+    if len(args.args) == 0:
+        launcher.ensure_db_ready()
+    # launches the explorer
+    launcher.launch(args.args or ["up", "--build"])
 
 
 if __name__ == "__main__":

--- a/testing/invariant/explorer.py
+++ b/testing/invariant/explorer.py
@@ -99,7 +99,8 @@ def released_versions(repository):
         r = requests.get(
             url,
             headers={
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15"
+                # make sure to not get cached versions
+                "Cache-Control": "no-cache",
             },
         )
         r.raise_for_status()
@@ -119,7 +120,6 @@ def released_versions(repository):
         # check for rate limits
         if e.response.status_code == 403:
             print("GitHub API rate limit reached, please try again later.")
-            return [{"name": "v0.0.2"}]
             exit(1)
     except requests.exceptions.ConnectionError:
         print(
@@ -140,7 +140,8 @@ def github_file(repository, tag, path):
         r = requests.get(
             url,
             headers={
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15"
+                # make sure to not get cached versions
+                "Cache-Control": "no-cache",
             },
         )
         r.raise_for_status()

--- a/testing/invariant/explorer.py
+++ b/testing/invariant/explorer.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""CLI to launch the Invariant Explorer as a Docker compose application."""
+
+import argparse
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+parser = argparse.ArgumentParser(
+    prog="invariant explorer",
+    description="Launch the Invariant Explorer as a Docker compose application.",
+)
+parser.add_argument(
+    "--port", type=int, default=80, help="The port to expose the Invariant Explorer on."
+)
+
+args = None
+
+
+def ensure_has_docker_compose():
+    """Ensure that the user has Docker Compose installed."""
+    try:
+        p = subprocess.Popen(
+            ["docker", "compose", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        p.communicate()
+
+        if p.returncode != 0:
+            raise Exception(
+                "Docker Compose is not installed. Please go to https://docs.docker.com/compose/install/ to install it and then re-run this command."
+            )
+    except FileNotFoundError:
+        raise Exception(
+            "Docker Compose is not installed. Please go to https://docs.docker.com/compose/install/ to install it and then re-run this command."
+        )
+
+
+def ensure_has_docker_network():
+    """Ensure that the user has the Docker network that the Invariant Explorer uses `invariant-explorer-web`."""
+    p = subprocess.Popen(
+        ["docker", "network", "ls", "--filter", "name=invariant-explorer-web"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    p.communicate()
+
+    if p.returncode != 0:
+        p = subprocess.Popen(
+            ["docker", "network", "create", "invariant-explorer-web"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        p.communicate()
+
+        if p.returncode != 0:
+            raise Exception(
+                "Failed to create the Docker network that the Invariant Explorer uses. Please check the logs for more information."
+            )
+
+
+def ensure_has_db_folder():
+    """Ensure that the user has the database folder that the Invariant Explorer uses."""
+    Path("./data/database").mkdir(parents=True, exist_ok=True)
+
+
+def latest_docker_compose_setup():
+    s = """
+services:
+  traefik:
+    image: traefik:v2.0
+    container_name: "${APP_NAME}-local-traefik"
+    command:
+      - --providers.docker=true
+      # Enable the API handler in insecure mode,
+      # which means that the Traefik API will be available directly
+      # on the entry point named traefik.
+      - --api.insecure=true
+      # Define Traefik entry points to port [80] for http and port [443] for https.
+      - --entrypoints.web.address=0.0.0.0:80
+      - --log.level=INFO
+    networks:
+      - web
+    ports:
+      - '${PORT_HTTP}:80'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik-http.entrypoints=web"
+
+  app-api:
+    image: ghcr.io/invariantlabs-ai/explorer-oss/app-api:latest
+    platform: linux/amd64
+    depends_on:
+      - database
+    working_dir: /srv/app
+    env_file:
+      - .env
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - MODAL_TOKEN_ID=${MODAL_TOKEN_ID}
+      - MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}
+      - PROJECTS_DIR=/srv/projects
+      - KEYCLOAK_CLIENT_ID_SECRET=${KEYCLOAK_CLIENT_ID_SECRET}
+      - TZ=Europe/Berlin
+      - DEV_MODE=${DEV_MODE}
+      - APP_NAME=${APP_NAME}
+      - CONFIG_FILE=/config/explorer.config.yml
+    networks:
+      - web
+      - internal
+    volumes:
+      - $CONFIG_FILE_NAME:/config/explorer.config.yml
+      - ./data/images:/srv/images
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.$APP_NAME-api.rule=(Host(`localhost`) && PathPrefix(`/api/`)) || (Host(`127.0.0.1`) && PathPrefix(`/api/`))"
+      - "traefik.http.routers.$APP_NAME-api.entrypoints=web"
+      - "traefik.http.services.$APP_NAME-api.loadbalancer.server.port=8000"
+      - "traefik.docker.network=invariant_web"
+
+  app-ui:
+    image: ghcr.io/invariantlabs-ai/explorer-oss/app-ui:latest
+    platform: linux/amd64
+    networks:
+      - web
+    volumes:
+      - $CONFIG_FILE_NAME:/config/explorer.config.yml
+    environment:
+      - APP_NAME=${APP_NAME}
+      - VITE_CONFIG_FILE=/config/explorer.config.yml
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.$APP_NAME-ui.rule=Host(`localhost`)||Host(`127.0.0.1`)"
+      - "traefik.http.routers.$APP_NAME-ui.entrypoints=web"
+      - "traefik.http.services.$APP_NAME-ui.loadbalancer.server.port=8000"
+      - "traefik.docker.network=invariant_web"
+
+  database:
+    image: postgres:16
+    env_file:
+      - .env
+    networks:
+      - internal
+    volumes:
+      - type: bind
+        source: ./data/database
+        target: /var/lib/postgresql/data
+
+networks:
+  web:
+  internal:"""
+
+    tf = tempfile.NamedTemporaryFile(
+        delete=False, prefix="docker-compose-", suffix=".yml"
+    )
+
+    with open(tf.name, "w") as f:
+        f.write(s)
+
+    return tf.name
+
+
+def config_file():
+    s = """# this configuration file is available both in the frontend and the backend
+# WARNING: never put any sensitive information in this file, as it is exposed to the client
+
+# limit at which the content of a message will be truncated (UI and on the API)
+truncation_limit: 10000
+server_truncation_limit: 100000
+
+# the name of this deployment instance (e.g. prod, local, preview, <custom name>)
+instance_name: local
+
+## authentication setup (Keycloak)
+
+# realm name for authentication
+authentication_realm: invariant-dev
+# prefix of the client ID used to identify the authentication client (e.g. invariant- will be expanded to invariant-$APP_NAME)
+authentication_client_id_prefix: invariant-dev
+
+# whether this is a private instance or not (private instances do not offer a public homepage or any form of anonymous access)
+private: false
+
+# whether telemetry is enabled for this instance
+telemetry: true"""
+
+    tf = tempfile.NamedTemporaryFile(
+        delete=False, prefix="explorer.config-", suffix=".yml"
+    )
+
+    with open(tf.name, "w") as f:
+        f.write(s)
+
+    return tf.name
+
+
+def ensure_dot_env_exists():
+    if not os.path.exists(".env"):
+        with open(".env", "w") as f:
+            f.write("""POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=invariantmonitor
+POSTGRES_HOST=database
+
+PGADMIN_DEFAULT_EMAIL=admin@mail.com
+PGADMIN_DEFAULT_PASSWORD=admin""")
+
+
+def launch_explorer(args=None):
+    """Launch the Invariant Explorer as a Docker compose application."""
+    # download l
+
+    if args is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(args)
+
+    compose_file = latest_docker_compose_setup()
+    cf = config_file()
+
+    print(compose_file)
+
+    ensure_has_docker_compose()
+    ensure_has_docker_network()
+    ensure_has_db_folder()
+    ensure_dot_env_exists()
+
+    env = {
+        **dict(os.environ),
+        "APP_NAME": "explorer-local",
+        "DEV_MODE": "true",
+        "CONFIG_FILE_NAME": cf,
+        "PREVIEW": "0",
+        "PORT_HTTP": str(args.port),
+        "PORT_API": "8000",
+        "KEYCLOAK_CLIENT_ID_SECRET": "local-does-not-use-keycloak",
+    }
+
+    p = subprocess.Popen(
+        # make sure paths are relative to the current directory
+        [
+            "docker",
+            "compose",
+            "-f",
+            compose_file,
+            "--project-directory",
+            ".",
+            "up",
+            "--build",
+        ],
+        env=env,
+    )
+    p.communicate()
+
+    if p.returncode != 0:
+        raise Exception(
+            "Failed to launch the Invariant Explorer. Please check the logs for more information."
+        )
+
+
+if __name__ == "__main__":
+    launch_explorer()

--- a/testing/invariant/explorer.py
+++ b/testing/invariant/explorer.py
@@ -104,12 +104,7 @@ def released_versions(repository):
 
 
 def github_file(repository, tag, path):
-    """Download a file from a GitHub repository."""
-    # for branches URLs are:
-    # //raw.githubusercontent.com/invariantlabs-ai/explorer-public/refs/heads/v0.1/docker-compose.yml
-    # for tags URLs are:
-    # //raw.githubusercontent.com/invariantlabs-ai/explorer-public/refs/tags/v0.1/docker-compose.yml
-
+    """Download a file from a public GitHub repository."""
     try:
         url = (
             f"https://raw.githubusercontent.com/{repository}/refs/heads/{tag}/{path}"
@@ -136,7 +131,7 @@ def docker_compose_setup(version):
 
     with open(tf.name, "w") as f:
         contents = github_file(
-            "invariantlabs-ai/explorer-public", version, "docker-compose.yml"
+            "invariantlabs-ai/explorer-public", version, "docker-compose.stable.yml"
         )
         f.write(contents)
 

--- a/testing/invariant/explorer.py
+++ b/testing/invariant/explorer.py
@@ -162,7 +162,7 @@ def docker_compose_setup(version):
 
     with open(tf.name, "w") as f:
         contents = github_file(
-            "invariantlabs-ai/explorer-public", version, "docker-compose.stable.yml"
+            "invariantlabs-ai/explorer", version, "docker-compose.stable.yml"
         )
         f.write(contents)
 
@@ -177,7 +177,7 @@ def config_file(version):
 
     with open(tf.name, "w") as f:
         contents = github_file(
-            "invariantlabs-ai/explorer-public",
+            "invariantlabs-ai/explorer",
             version,
             "configs/explorer.local.yml",
         )
@@ -195,7 +195,7 @@ class ExplorerLauncher:
         # gets the config and docker compose files for the specified version or branch
         version = args.version
         if version == "stable":
-            versions = released_versions("invariantlabs-ai/explorer-public")
+            versions = released_versions("invariantlabs-ai/explorer")
             if len(versions) == 0:
                 print(
                     "No published versions of Explorer found. Please specify a specific version using --version=vX.Y.Z."

--- a/testing/poetry.lock
+++ b/testing/poetry.lock
@@ -111,13 +111,13 @@ speedups = ["Brotli", "aiodns (>=3.2.0)", "brotlicffi"]
 
 [[package]]
 name = "aiosignal"
-version = "1.3.1"
+version = "1.3.2"
 description = "aiosignal: a list of registered asynchronous callbacks"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 files = [
-    {file = "aiosignal-1.3.1-py3-none-any.whl", hash = "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"},
-    {file = "aiosignal-1.3.1.tar.gz", hash = "sha256:54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc"},
+    {file = "aiosignal-1.3.2-py2.py3-none-any.whl", hash = "sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5"},
+    {file = "aiosignal-1.3.2.tar.gz", hash = "sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54"},
 ]
 
 [package.dependencies]
@@ -233,13 +233,13 @@ lxml = ["lxml"]
 
 [[package]]
 name = "certifi"
-version = "2024.8.30"
+version = "2024.12.14"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
-    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
+    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
+    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
 ]
 
 [[package]]
@@ -1040,20 +1040,20 @@ files = [
 
 [[package]]
 name = "langchain"
-version = "0.3.11"
+version = "0.3.12"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "langchain-0.3.11-py3-none-any.whl", hash = "sha256:6655feded1f7569e5a4bd11e38de0a26c7c86646c0dea49afccceba42df60ad7"},
-    {file = "langchain-0.3.11.tar.gz", hash = "sha256:17868ea3f0cf5a46b4b88bf1961c4a12d32ea0778930e7d2eb5103e0287ff478"},
+    {file = "langchain-0.3.12-py3-none-any.whl", hash = "sha256:581ad93a9de12e4b957bc2af9ba8482eb86e3930e84c4ee20ed677da5e2311cd"},
+    {file = "langchain-0.3.12.tar.gz", hash = "sha256:0d8247afbf37beb263b4adc29f7aa8a5ae83c43a6941894e2f9ba39d5c869e3b"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.8.3,<4.0.0"
 async-timeout = {version = ">=4.0.0,<5.0.0", markers = "python_version < \"3.11\""}
-langchain-core = ">=0.3.24,<0.4.0"
-langchain-text-splitters = ">=0.3.0,<0.4.0"
+langchain-core = ">=0.3.25,<0.4.0"
+langchain-text-splitters = ">=0.3.3,<0.4.0"
 langsmith = ">=0.1.17,<0.3"
 numpy = [
     {version = ">=1.22.4,<2", markers = "python_version < \"3.12\""},
@@ -1067,21 +1067,21 @@ tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10"
 
 [[package]]
 name = "langchain-community"
-version = "0.3.11"
+version = "0.3.12"
 description = "Community contributed LangChain integrations."
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "langchain_community-0.3.11-py3-none-any.whl", hash = "sha256:c67091dc7652f44161bbea915c03a296f3c1ef2a8dfbcb475cdf23a1deb9790e"},
-    {file = "langchain_community-0.3.11.tar.gz", hash = "sha256:31a96de1578f6037cd49acf287227d54e88e81f82e3e49cb4d90bfe05b1cdc32"},
+    {file = "langchain_community-0.3.12-py3-none-any.whl", hash = "sha256:5a993c931d46dc07fcdfcdfa4d87095c5a15d37ff32b0c16e9ecf6f5caa58c9c"},
+    {file = "langchain_community-0.3.12.tar.gz", hash = "sha256:b4694f34c7214dede03fe5a75e9f335e16bd788dfa6ca279302ad357bf0d0fc4"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.8.3,<4.0.0"
 dataclasses-json = ">=0.5.7,<0.7"
 httpx-sse = ">=0.4.0,<0.5.0"
-langchain = ">=0.3.11,<0.4.0"
-langchain-core = ">=0.3.24,<0.4.0"
+langchain = ">=0.3.12,<0.4.0"
+langchain-core = ">=0.3.25,<0.4.0"
 langsmith = ">=0.1.125,<0.3"
 numpy = [
     {version = ">=1.22.4,<2", markers = "python_version < \"3.12\""},
@@ -1095,13 +1095,13 @@ tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10"
 
 [[package]]
 name = "langchain-core"
-version = "0.3.24"
+version = "0.3.25"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "langchain_core-0.3.24-py3-none-any.whl", hash = "sha256:97192552ef882a3dd6ae3b870a180a743801d0137a1159173f51ac555eeb7eec"},
-    {file = "langchain_core-0.3.24.tar.gz", hash = "sha256:460851e8145327f70b70aad7dce2cdbd285e144d14af82b677256b941fc99656"},
+    {file = "langchain_core-0.3.25-py3-none-any.whl", hash = "sha256:e10581c6c74ba16bdc6fdf16b00cced2aa447cc4024ed19746a1232918edde38"},
+    {file = "langchain_core-0.3.25.tar.gz", hash = "sha256:fdb8df41e5cdd928c0c2551ebbde1cea770ee3c64598395367ad77ddf9acbae7"},
 ]
 
 [package.dependencies]
@@ -1134,17 +1134,17 @@ tiktoken = ">=0.7,<1"
 
 [[package]]
 name = "langchain-text-splitters"
-version = "0.3.2"
+version = "0.3.3"
 description = "LangChain text splitting utilities"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "langchain_text_splitters-0.3.2-py3-none-any.whl", hash = "sha256:0db28c53f41d1bc024cdb3b1646741f6d46d5371e90f31e7e7c9fbe75d01c726"},
-    {file = "langchain_text_splitters-0.3.2.tar.gz", hash = "sha256:81e6515d9901d6dd8e35fb31ccd4f30f76d44b771890c789dc835ef9f16204df"},
+    {file = "langchain_text_splitters-0.3.3-py3-none-any.whl", hash = "sha256:c2f8650457685072971edc8c52c9f8826496b3307f28004a7fd09eb32d4d819f"},
+    {file = "langchain_text_splitters-0.3.3.tar.gz", hash = "sha256:c596958dcab15fdfe0627fd36ce9d588d0a7e35593af70cd10d0a4a06d69b3ee"},
 ]
 
 [package.dependencies]
-langchain-core = ">=0.3.15,<0.4.0"
+langchain-core = ">=0.3.25,<0.4.0"
 
 [[package]]
 name = "langgraph"
@@ -1164,13 +1164,13 @@ langgraph-sdk = ">=0.1.42,<0.2.0"
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "2.0.8"
+version = "2.0.9"
 description = "Library with base interfaces for LangGraph checkpoint savers."
 optional = false
 python-versions = "<4.0.0,>=3.9.0"
 files = [
-    {file = "langgraph_checkpoint-2.0.8-py3-none-any.whl", hash = "sha256:c65243e0d759ca6f556d01fc0039c545fdc8c6917214e750c9ecf8a7bc78bec6"},
-    {file = "langgraph_checkpoint-2.0.8.tar.gz", hash = "sha256:897c21d677d62946481334b3b37e8ae25f6b7fd474f3bc4ee3715ec5fd5f6055"},
+    {file = "langgraph_checkpoint-2.0.9-py3-none-any.whl", hash = "sha256:b546ed6129929b8941ac08af6ce5cd26c8ebe1d25883d3c48638d34ade91ce42"},
+    {file = "langgraph_checkpoint-2.0.9.tar.gz", hash = "sha256:43847d7e385a2d9d2b684155920998e44ed42d2d1780719e4f6111fe3d6db84c"},
 ]
 
 [package.dependencies]
@@ -1179,13 +1179,13 @@ msgpack = ">=1.1.0,<2.0.0"
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.1.43"
+version = "0.1.45"
 description = "SDK for interacting with LangGraph API"
 optional = false
 python-versions = "<4.0.0,>=3.9.0"
 files = [
-    {file = "langgraph_sdk-0.1.43-py3-none-any.whl", hash = "sha256:b299dd091a7547dba0ffd041ccacadd1caeb57e0c52f2ccf80de64eac45f6e7a"},
-    {file = "langgraph_sdk-0.1.43.tar.gz", hash = "sha256:3df9c1bc946dcaf0e3e4453e51509166495e2ce1dcd2273426e22ff9317e64f5"},
+    {file = "langgraph_sdk-0.1.45-py3-none-any.whl", hash = "sha256:bbb1d4777025336acaf3a5a871b27a5da5600a072b80c1a2707484c6e661bbae"},
+    {file = "langgraph_sdk-0.1.45.tar.gz", hash = "sha256:d48f7af3e0d1690771dddb861aca92e8f4955724836693026433a4d9097fe456"},
 ]
 
 [package.dependencies]
@@ -1675,13 +1675,13 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.57.2"
+version = "1.57.4"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "openai-1.57.2-py3-none-any.whl", hash = "sha256:f7326283c156fdee875746e7e54d36959fb198eadc683952ee05e3302fbd638d"},
-    {file = "openai-1.57.2.tar.gz", hash = "sha256:5f49fd0f38e9f2131cda7deb45dafdd1aee4f52a637e190ce0ecf40147ce8cee"},
+    {file = "openai-1.57.4-py3-none-any.whl", hash = "sha256:7def1ab2d52f196357ce31b9cfcf4181529ce00838286426bb35be81c035dafb"},
+    {file = "openai-1.57.4.tar.gz", hash = "sha256:a8f071a3e9198e2818f63aade68e759417b9f62c0971bdb83de82504b70b77f7"},
 ]
 
 [package.dependencies]
@@ -1811,6 +1811,20 @@ files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+description = "Pexpect allows easy control of interactive console applications."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
+    {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
+]
+
+[package.dependencies]
+ptyprocess = ">=0.5"
 
 [[package]]
 name = "pillow"
@@ -2050,6 +2064,17 @@ files = [
 ]
 
 [[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.10.3"
 description = "Data validation using Python type hints"
@@ -2183,13 +2208,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.6.1"
+version = "2.7.0"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_settings-2.6.1-py3-none-any.whl", hash = "sha256:7fb0637c786a558d3103436278a7c4f1cfd29ba8973238a50c5bb9a55387da87"},
-    {file = "pydantic_settings-2.6.1.tar.gz", hash = "sha256:e0f92546d8a9923cb8941689abf85d6601a8c19a23e97a34b2964a2e3f813ca0"},
+    {file = "pydantic_settings-2.7.0-py3-none-any.whl", hash = "sha256:e00c05d5fa6cbbb227c84bd7487c5c1065084119b750df7c8c1a554aed236eb5"},
+    {file = "pydantic_settings-2.7.0.tar.gz", hash = "sha256:ac4bfd4a36831a48dbf8b2d9325425b549a0a6f18cea118436d728eb4f1c4d66"},
 ]
 
 [package.dependencies]
@@ -2919,4 +2944,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.10, <4.0"
-content-hash = "d9b1bf56e25d8af2428b18507af9ce7512451a0a9f2cbd499d6069639e7e9a25"
+content-hash = "5d19a05d97a41ef3a5adecd0b2153194b5cb0c38468089b8d5382fa1dbd85d03"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -17,6 +17,7 @@ Pillow = "^10.0.0"
 beautifulsoup4 = "^4.12.3"
 invariant-sdk = "^0.0.4"
 diskcache = "^5.6.3"
+pexpect = "^4.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^5.0.0"


### PR DESCRIPTION
Task: https://trello.com/c/DSOUCpuK/161-allow-invariant-explorer-cli-tool-that-fetches-docker-composeyml-from-repo-and-launches-a-local-explorer-instance

This PR allows users to easily pull and launch Explorer on their own machine. For this, the added CLI command `invariant explorer` does the following:

1. It checks the OSS explorer repo for the list of available release versions (v* Git tags)
2. It picks the latest of these release versions (or alternatively `main` if specified via `--version=main`)
3. It downloads/updates the [`docker-compose.yml`](https://github.com/invariantlabs-ai/explorer-public/blob/main/docker-compose.yml) and the [`explorer.local.yml`](https://github.com/invariantlabs-ai/explorer-public/blob/main/configs/explorer.local.yml) file from this repo.
4. It launches a Docker compose stack

The resulting Docker Compose stack will pull in the specified tagged version of the `app-ui` and `app-api` services, as published on `ghcr.io` (GitHub container registry) by CI of the Explorer OSS repo.

This allows us to release Explorer versions via Git tag in the Explorer OSS repo. The only change that this setup still needs is to open source the actual Explorer repo and replace the occurrences of `invariantlabs-a/explorer-public` in this PR. Also, we need to make sure the Explorer OSS repo only pushes versioned and latest images, once CI passes.