### PR TITLE
Fix PyPi publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,8 @@ jobs:
           poetry build
 
       - name: Store as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
+          path: dist/
+          retention-days: 7 # Optional: Keep artifacts for 7 days (default is 90)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,24 +28,15 @@ jobs:
       - name: Build package
         run: |
           poetry build
-
-      - name: Store as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-          retention-days: 7 # Optional: Keep artifacts for 7 days (default is 90)
-
+      
+      # Install invariant package in a virtual environment for testing
       - name: Create virtual environment
         run: |
           python -m venv venv
           source venv/bin/activate
-
-      - name: Install dependencies
-        run: |
-          source venv/bin/activate
           pip install dist/*.whl
-
+        
+      # Make sure the tests pass when the package is built and installed
       - name: Run tests
         env:
           OPENAI_API_KEY: ${{ secrets.INVARIANT_TESTING_OPENAI_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,11 +25,6 @@ jobs:
           pip install poetry==2.1.1
           poetry install
 
-      # print poetry version
-      - name: Print poetry version
-        run: |
-          poetry --version
-
       - name: Build package
         run: |
           poetry build
@@ -52,6 +47,8 @@ jobs:
           pip install dist/*.whl
 
       - name: Run tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.INVARIANT_TESTING_OPENAI_KEY }}
         run: |
           source venv/bin/activate
           python -m pytest invariant/tests/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,23 +30,23 @@ jobs:
           poetry build
       
       # Install invariant package in a virtual environment for testing
-      - name: Create virtual environment and install package
-        run: |
-          python -m venv venv
-          source venv/bin/activate
-          pip install dist/*.whl
+      #- name: Create virtual environment and install package
+      #  run: |
+      #    python -m venv venv
+      #    source venv/bin/activate
+      #    pip install dist/*.whl
         
       # Make sure the tests pass when the package is built and installed
-      - name: Run tests
-        env:
-          OPENAI_API_KEY: ${{ secrets.INVARIANT_TESTING_OPENAI_KEY }}
-        run: |
-          source venv/bin/activate
-          python -m pytest invariant/tests/
+      #- name: Run tests
+      #  env:
+      #    OPENAI_API_KEY: ${{ secrets.INVARIANT_TESTING_OPENAI_KEY }}
+      #  run: |
+      #    source venv/bin/activate
+      #    python -m pytest invariant/tests/
 
       - name: Set TestPyPI credentials
         run: |
-          poetry config repositories.testpypi https://test.pypi.org/simple/
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
           poetry config pypi-token.testpypi ${{ secrets.TESTPYPI_API_TOKEN }}
       
       # Publish to TestPyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,20 @@
 name: Publish to PyPI
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Invariant testing CI
+    types:
+      - completed
     branches:
-      - publish-testing
+      - v*
 
 jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
     environment: pypi-package
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref_type == 'tag' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -30,26 +35,24 @@ jobs:
           poetry build
       
       # Install invariant package in a virtual environment for testing
-      #- name: Create virtual environment and install package
-      #  run: |
-      #    python -m venv venv
-      #    source venv/bin/activate
-      #    pip install dist/*.whl
+      - name: Create virtual environment and install package
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install dist/*.whl
         
       # Make sure the tests pass when the package is built and installed
-      #- name: Run tests
-      #  env:
-      #    OPENAI_API_KEY: ${{ secrets.INVARIANT_TESTING_OPENAI_KEY }}
-      #  run: |
-      #    source venv/bin/activate
-      #    python -m pytest invariant/tests/
+      - name: Run tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.INVARIANT_TESTING_OPENAI_KEY }}
+        run: |
+          source venv/bin/activate
+          python -m pytest invariant/tests/
 
-      - name: Set TestPyPI credentials
+      - name: Set PyPI credentials
         run: |
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry config pypi-token.testpypi ${{ secrets.TESTPYPI_API_TOKEN }}
+          poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
       
-      # Publish to TestPyPI
-      - name: Publish to TestPyPI
+      - name: Publish to PyPI
         run: |
-          poetry publish -r testpypi --dist-dir dist
+          poetry publish --dist-dir dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish to PyPI
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - publish-testing
 
 jobs:
   pypi-publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,10 @@ jobs:
           pip install poetry
           poetry install
 
-      - name: Set PyPI credentials
+      # print poetry version
+      - name: Print poetry version
         run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
+          poetry --version
 
       - name: Build package
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,22 +3,22 @@ name: Publish to PyPI
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   pypi-publish:
     name: Upload release to PyPI
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     environment: pypi-package
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python 3.12.2
         uses: actions/setup-python@v3
         with:
           python-version: "3.12.2"
-      
+
       - name: Setup dependencies
         run: |
           python -m pip install --upgrade pip
@@ -29,6 +29,11 @@ jobs:
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Publish to PyPI
+      - name: Build package
         run: |
-          poetry publish --build
+          poetry build
+
+      - name: Store as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==2.1.1
           poetry install
 
       # print poetry version
@@ -40,3 +40,18 @@ jobs:
           name: dist
           path: dist/
           retention-days: 7 # Optional: Keep artifacts for 7 days (default is 90)
+
+      - name: Create virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+
+      - name: Install dependencies
+        run: |
+          source venv/bin/activate
+          pip install dist/*.whl
+
+      - name: Run tests
+        run: |
+          source venv/bin/activate
+          python -m pytest invariant/tests/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           poetry build
       
       # Install invariant package in a virtual environment for testing
-      - name: Create virtual environment
+      - name: Create virtual environment and install package
         run: |
           python -m venv venv
           source venv/bin/activate
@@ -43,3 +43,13 @@ jobs:
         run: |
           source venv/bin/activate
           python -m pytest invariant/tests/
+
+      - name: Set TestPyPI credentials
+        run: |
+          poetry config repositories.testpypi https://test.pypi.org/simple/
+          poetry config pypi-token.testpypi ${{ secrets.TESTPYPI_API_TOKEN }}
+      
+      # Publish to TestPyPI
+      - name: Publish to TestPyPI
+        run: |
+          poetry publish -r testpypi --dist-dir dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "invariant-ai"
+name = "invariant-ai-test"
 version = "0.2.0"
 description = "Invariant policy language"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,5 @@ testpaths = ["invariant/tests"]
 invariant = "invariant.__main__:main"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.metadata]
-allow-direct-references = true
-
-[tool.hatch.build.targets.wheel]
-packages = ["invariant"]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "invariant-ai-test"
+name = "invariant-ai"
 version = "0.2.0"
 description = "Invariant policy language"
 readme = "README.md"


### PR DESCRIPTION
Fix publishing to PyPi and add extra guardrails:
- Only push if all tests ran successfully
- Only push if we can run all tests successfully using the built package